### PR TITLE
fix fonts/assets path

### DIFF
--- a/kapow-grunt/gruntfile.js
+++ b/kapow-grunt/gruntfile.js
@@ -205,7 +205,7 @@ module.exports = function(grunt) {
 				// -------------------------------------
 				{
 					src: ['<%= siteInfo.assets_path %>/<%= siteInfo.fonts_dir %>/**'],
-					dest: '<%= wpInfo.wp_content %>/themes/<%= wpInfo.theme_name %>/<%= wpInfo.assets_dir %>/<%= wpInfo.fonts_dir %>/'
+					dest: '<%= wpInfo.wp_content %>/themes/<%= wpInfo.theme_name %>/'
 				}
 			]
 		}


### PR DESCRIPTION
#8
@davetgreen 
I think it was taking the folder structure with it in the src bit and copying the _whole_ thing.
So `assets/fonts/**` into the destination directory `assets/fonts/`?